### PR TITLE
Fix pkgconf package typo in Gentoo chariot

### DIFF
--- a/Gentoo/chariot.sh
+++ b/Gentoo/chariot.sh
@@ -592,11 +592,11 @@ checkpoint_26() {
 run_checkpoint 26 "sudo -E emerge dev-libs/glib" checkpoint_26
 
 checkpoint_27() {
-    sudo -E emerge dev-util/pkgcon
-    rm -rf /var/tmp/portage/dev-util/pkgcon-*
+    sudo -E emerge dev-util/pkgconf
+    rm -rf /var/tmp/portage/dev-util/pkgconf-*
     eclean-dist -d
 }
-run_checkpoint 27 "sudo -E emerge dev-util/pkgcon" checkpoint_27
+run_checkpoint 27 "sudo -E emerge dev-util/pkgconf" checkpoint_27
 
 checkpoint_28() {
     sudo -E emerge dev-cpp/gtest


### PR DESCRIPTION
Gentoo has no dev-util/pkgcon ebuild, causing checkpoint 27 to fail during installation. The equivalent Arch checkpoint also installs pkgconf, which confirms the intended package.