### PR TITLE
Fix OBS checkpoint function reference in Gentoo Chariot

### DIFF
--- a/Gentoo/chariot.sh
+++ b/Gentoo/chariot.sh
@@ -1455,7 +1455,7 @@ checkpoint_134() {
     rm -rf /var/tmp/portage/media-video/obs-studio-*
     eclean-dist -d
 }
-run_checkpoint 134 "sudo -E emerge media-video/obs-studio" checkpoint_131
+run_checkpoint 134 "sudo -E emerge media-video/obs-studio" checkpoint_134
 
 checkpoint_135() {
     USE="ruby_targets_ruby40" sudo -E emerge dev-lang/ruby


### PR DESCRIPTION
This fixes an incorrect checkpoint function reference in the Gentoo Chariot installer.

Checkpoint 134 defines the OBS Studio installation in checkpoint_134, but run_checkpoint currently invokes checkpoint_131, causing the GIMP checkpoint to run again instead of the OBS installation.