### PR TITLE
Remove stray libva driver command

### DIFF
--- a/Gentoo/chariot.sh
+++ b/Gentoo/chariot.sh
@@ -1318,7 +1318,6 @@ run_checkpoint 123 "sudo -E emerge vlc" checkpoint_123
 
 checkpoint_124() {
     sudo -E emerge media-libs/libva
-    libva-intel-media-driver
     rm -rf /var/tmp/portage/media-libs/libva-*
     eclean-dist -d
 }


### PR DESCRIPTION
This removes a stray `libva-intel-media-driver` line from checkpoint 124 in the Gentoo Chariot installer.

The line is executed as a command rather than installed through Portage, so it can fail with `command not found`. The Intel media driver is already handled correctly in checkpoint 125, where Intel GPU detection is performed before `media-libs/libva-intel-media-driver` is emerged.

Removing the stray command keeps checkpoint 124 focused on installing `media-libs/libva` and leaves the driver installation to checkpoint 125.
