### PR TITLE
Fix QEMU checkpoint function call

### DIFF
--- a/Gentoo/chariot.sh
+++ b/Gentoo/chariot.sh
@@ -1522,7 +1522,7 @@ checkpoint_140() {
     eclean-dist -d
 
 }
-run_checkpoint 141 "Chard Bubblepatch" checkpoint_141
+run_checkpoint 140 "Chard Bubblepatch" checkpoint_140
 
 checkpoint_142() {
     sudo -E emerge gedit


### PR DESCRIPTION
QEMU installation is defined in checkpoint_140, but the following run_checkpoint call references checkpoint 141 and `checkpoint_141`, which is not defined. As a result, QEMU checkpoint is skipped and Chariot attempts to invoke a nonexistent function.

This changes the call to use checkpoint 140 and `checkpoint_140`.
